### PR TITLE
Refactor ProblemInput component to handle undefined thisProblem

### DIFF
--- a/src/components/ProblemInput.jsx
+++ b/src/components/ProblemInput.jsx
@@ -236,7 +236,7 @@ try {
           {/* NOTE - this render function does error handling for test cases returned with incorrect format and triggers reload.  */}
           {/* {!results && renderTestCases()} */}
           {console.log(thisProblem)}
-          {!results && thisProblem.testCases && renderTestCases()}
+          {!results && thisProblem != undefined && thisProblem.testCases && renderTestCases()}
 
         </pre>
       </div>


### PR DESCRIPTION
This pull request refactors the ProblemInput component to handle the case when `thisProblem` is undefined. Previously, the component would throw an error when `thisProblem` was undefined, but now it gracefully handles this scenario and renders the test cases only when `thisProblem` is defined.